### PR TITLE
Allow configurable conn pool size

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -56,6 +56,7 @@ func MongDBBackend() backend.MasterLock {
 			Name:    "gomastertest",
 			Timeout: time.Duration(1 * time.Second),
 			UseSSL:  false,
+			PoolLimit: 4,
 		},
 		Logger: logger,
 	})
@@ -77,6 +78,7 @@ func MySQLBackend() backend.MasterLock {
 		DBName:   "gomastertest",
 		CreateDB: true,
 		Logger:   logger,
+		MaxOpenConnections: 5,
 	})
 
 	if err := mysqlBackend.Connect(); err != nil {


### PR DESCRIPTION
This PR updates the Mongo and MySQL backend configs to allow the connection pool limits to be set. I also update the `setDefaults` in each to use the default value defined [in BCP037](https://invision-engineering.herokuapp.com/best_current_practices/BCP037/connection_pools_continued.html)