### PR TITLE
Switched from satori version of uuid to the gofrs-maintained fork

### DIFF
--- a/master.go
+++ b/master.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/InVisionApp/go-logger"
 	"github.com/relistan/go-director"
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 
 	"github.com/InVisionApp/go-logger/shims/logrus"
 	"github.com/InVisionApp/go-master/backend"


### PR DESCRIPTION
The satori version of the uuid library doesn't seem to be maintained anymore, so gofrs forked it and fixed a few outstanding bugs.  Should be backward compatible with the satori API, but maintained going forward.

There's no hurry on merging this since I don't think any of us are impacted by any of the bugs they fixed.  I'll eventually have a PR for go-background that also switches to this version of the library.