### PR TITLE
Made the TIMESTAMP columns NULLable for MySQL 5.7 compliance.

### DIFF
--- a/backend/mysql/mysql.go
+++ b/backend/mysql/mysql.go
@@ -208,8 +208,8 @@ func (m *MySQLBackend) createTable() error {
 		`id INT NOT NULL PRIMARY KEY,`+
 		`master_id CHAR(36) UNIQUE,`+
 		`version VARCHAR(255),`+
-		`started_at TIMESTAMP,`+
-		`last_heartbeat TIMESTAMP`+
+		`started_at TIMESTAMP NULL,`+
+		`last_heartbeat TIMESTAMP NULL`+
 		`);`, m.TableName)
 
 	m.log.Info("Attempting to create lock table")


### PR DESCRIPTION
## Why this change?

After changing the database to MySQL 5.7, the `assets-api` service was crashing last start with the error message

`
{"environment":"dev","error":"could not setup job scheduler: could not set up master lock for job scheduler: could not connect master lock to db: unable to complete one or more migrations: unable to create lock table: Error 1067: Invalid default value for 'last_heartbeat'","level":"fatal","method":"main","msg":"Could not setup dependencies","time":"2020-11-11T16:20:34Z"}
`

The `masterlock` table creation was failing because `TIMESTAMP` in MySQL 5.7 expects a default value if not set to `NULL`.  The operations on master lock set these values explicitly and no database defaults are required.

Hence the create SQL statement was changed to make the two `TIMESTAMP` fields nullable.

## JIRA 

[SHAR-1214](https://invisionapp.atlassian.net/browse/SHAR-1214)

## Verification

This has been verified using `assets-api`.  There are no integration tests that are part of the suite to test this in isolation.


