### PR TITLE
Reduce heartbeat 'not able to become master' logs, once per second

### DIFF
--- a/master.go
+++ b/master.go
@@ -184,7 +184,9 @@ func (m *master) becomeMaster() bool {
 	}
 
 	if err := m.lock.Lock(mi); err != nil {
-		m.sendError(fmt.Errorf("failed to acquire lock while becoming master: %v", err))
+		// The heartbeat tries to become master every second. Logging an error here
+		// (at error level) is a constant stream.
+		m.log.Debugf("failed to acquire lock while becoming master: %v", err)
 		return false
 	}
 


### PR DESCRIPTION
In a (semi) recent pass to modify errors to use a "sendError" function, this one was included, and probably shouldn't have been. This library provides a once-per-second heartbeat where every pod tries to become the master. If there is already an existing lock (another master), it errors - which, prior to my changes in this PR, logs that error once per second, per non-master pod.

Prior to the 'sendError' update, this error was originally a debug level trace, but was (probably accidentally) upgraded to Error level. I'm putting it back down to debug which should reduce logging noise and volume.